### PR TITLE
Added NA handling for the request body

### DIFF
--- a/R/db_write_table.R
+++ b/R/db_write_table.R
@@ -63,7 +63,7 @@ postgrest_post <- function(url, header, data) {
   # Prepare the request
   req <- httr2::request(url) |>
     httr2::req_headers(!!!header) |>
-    httr2::req_body_json(data)
+    httr2::req_body_json(data, na = "null")
 
   # Make the request
   response <- req |>


### PR DESCRIPTION
Changed httr2::req_body_json(data) to httr2::req_body_json(data, na = "null") so all fields are retained when the data is converte to JSON. Without na = "null", field for one row that are NA are getting dropped and so each block in the JSON have varying fields leading to the error 400: All object keys must match.