### PR TITLE
if output_geom is set TRUE, changed 'true' to TRUE

### DIFF
--- a/R/db_read_table.R
+++ b/R/db_read_table.R
@@ -111,7 +111,7 @@ db_read_table <- function(table_name,
                 postgrest_resp_to_data(response)
             }
     } else {
-        if(output_geometry == "true") {
+        if(output_geometry == TRUE) {
               out <- sf::st_sf(sf::st_sfc(), crs = sf::st_crs("+proj=longlat +datum=WGS84"))
             } else{ out <- list()}
         for (page in 1:.n_pages) {


### PR DESCRIPTION
output_geometry was compared to the character "true" instead of the boolean TRUE, so `out` was never converted to an sf object thus leading to the error `object have different crs` at line 130 with `rbind(out, page_out).